### PR TITLE
Support dual runtime sync and expand sample dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ feature-monitoring-web/
 - `main.py`는 **Cloud 모드**(기본)와 **On-prem 모드**를 자동 전환합니다.
 - Cloud 모드에서는 `st.cache_data(ttl=86400)`로 하루 1회 공개 스테이징 API를 동기화하고, 실패 시 샘플 데이터(500건)를 사용합니다.
 - On-prem 모드에서는 `DataManager`가 사내 DRF API → Parquet 캐시로 싱크합니다.
+- 런타임 감지/데이터 로딩 로직은 `app/data/runtime_loader.py`에 모듈화되어 있어 브랜치 병합 시 충돌을 줄입니다.
 
 | 설정 키              | Cloud (Streamlit Secrets)                  | On-prem (환경 변수)                   |
 | ------------------ | ----------------------------------------- | ------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,128 @@
-"# ECO" 
+# ECO
+
+## 📁 레포지토리 구조 (제안)
+
+```
+
+feature-monitoring-web/
+├── developer_A/
+│   └── to_merge/         # 공유 대상 파일
+├── developer_B/
+├── developer_C/
+├── common/               # 공통 참고자료
+└── sync_log.md           # 이관 내역 간단 메모
+
+````
+
+### 📑 sync_log.md (기록 예시)
+
+```markdown
+# 2025-07-25
+- [B] streamlit_chart_v2.py → 회사 dev 브랜치 반영
+- [A] arch_driver_overview.md → 내부 참고용으로만 유지 (미반영)
+````
+
+> ✅ 간단한 메모 수준이면 충분하며, 필요 시만 작성해도 무방합니다.
+
+---
+
+## 🧪 Streamlit Cloud 테스트 브랜치
+
+- 이 브랜치는 **Streamlit Cloud 배포 실험**을 위해 최소 구성으로 유지합니다.
+- `main.py`는 `app/core/navigation.py`에 정의된 페이지 레지스트리를 사용하므로 필요한 화면을 간단히 추가할 수 있습니다.
+- 공용 의존성은 `requirements.txt`에 정리되어 있어 Cloud 환경에서도 바로 설치됩니다.
+
+> 구조를 간결하게 유지하면서도 페이지 확장에 대비한 형태입니다.
+
+---
+
+## 🚀 배포 가이드
+
+### 1. Git 원격 저장소로 올리기
+
+1. 새 브랜치에서 작업 중이라면 커밋을 완료합니다.
+   ```bash
+   git status
+   git add <파일>
+   git commit -m "feat: streamlit v4 layout"
+   ```
+2. 회사 GitHub 저장소를 원격으로 등록합니다. (이미 등록돼 있다면 생략)
+   ```bash
+   git remote add origin git@github.com:<org>/<repo>.git
+   ```
+3. 원하는 브랜치로 push 합니다.
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+> ℹ️ GPT 환경에서는 외부 네트워크 접속이 제한되어 **실제 push 명령은 실행할 수 없습니다.** 위 명령을 로컬 개발 환경이나 회사 CI에서 실행해주세요.
+
+### 2. Streamlit Cloud 배포하기
+
+1. [streamlit.io/cloud](https://streamlit.io/cloud)에 접속해 GitHub 계정으로 로그인합니다.
+2. “New app” 버튼을 눌러 위에서 push 한 저장소와 브랜치, `main.py` 진입 파일을 선택합니다.
+3. 필요 시 `requirements.txt`에 `streamlit`, `pandas` 등의 의존성을 명시합니다. (현재 레포지토리는 Streamlit 1.x, pandas를 사용합니다.)
+4. “Deploy”를 누르면 몇 분 내에 앱이 생성되며, 배포 URL이 발급됩니다.
+5. 추후 코드를 업데이트하면 `git push`만으로 Streamlit Cloud가 자동으로 재배포합니다.
+
+> 💡 사내망 정책으로 Streamlit Cloud 사용이 제한될 경우, 사내 Kubernetes/VM에 `streamlit run main.py --server.port <포트>` 형태로 배포하고 리버스 프록시를 연결하는 대안도 고려할 수 있습니다.
+
+### 3. Cloud / On-prem 런타임 전환
+
+- `main.py`는 **Cloud 모드**(기본)와 **On-prem 모드**를 자동 전환합니다.
+- Cloud 모드에서는 `st.cache_data(ttl=86400)`로 하루 1회 공개 스테이징 API를 동기화하고, 실패 시 샘플 데이터(500건)를 사용합니다.
+- On-prem 모드에서는 `DataManager`가 사내 DRF API → Parquet 캐시로 싱크합니다.
+
+| 설정 키              | Cloud (Streamlit Secrets)                  | On-prem (환경 변수)                   |
+| ------------------ | ----------------------------------------- | ------------------------------------ |
+| `RUNTIME_MODE`     | `cloud` (기본)                             | `onprem`                             |
+| `API_BASE`         | 공개 접근 가능한 스테이징 API URL             | 사내망 API 엔드포인트                   |
+| `VERIFY_SSL`       | `true`                                     | `false` 또는 내부 CA에 맞춰 설정            |
+| `API_ACCESS_TOKEN` | 필요 시 Bearer 토큰                         | 필요 시 서비스 토큰                      |
+| `DATA_DIR`         | -                                         | `/srv/fmw/_cache` 등 캐시 저장 경로         |
+
+#### Secrets 예시 (Streamlit Cloud)
+
+```toml
+RUNTIME_MODE = "cloud"
+API_BASE = "https://staging.example.com"
+VERIFY_SSL = "true"
+API_ACCESS_TOKEN = "<optional>"
+```
+
+#### On-prem 환경 변수 예시
+
+```bash
+export RUNTIME_MODE=onprem
+export API_BASE=https://10.x.x.x
+export DATA_DIR=/srv/fmw/_cache
+export VERIFY_SSL=false
+```
+
+---
+
+## 🔐 보안 정책
+
+| 구분                    | 정책                   |
+| --------------------- | -------------------- |
+| 정책 명세, MCC/MNC, DB 구조 | ❌ 절대 포함 금지           |
+| GPT 입력 내용             | ✅ 구조 설계, 흐름 설명만 허용   |
+| 회사 레포지토리 작업           | ✅ 실제 로직, 민감 정보 작성 허용 |
+
+---
+
+## 🤝 협업 규칙
+
+* 문서화보다 **주석 포함된 실 파일 중심 공유**
+* Slack에 `.md` 또는 `.py` 링크만 전달해도 충분
+* 공통 자료는 `common/` 폴더에 정리
+
+---
+
+📌 FMW는 메인 과제가 아니므로
+**가볍고 효율적인 협업**,
+**문서보다 실험 중심**,
+**회의보다 공유 중심**의
+**비동기 흐름**을 지향합니다.
+
+```

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core helpers for Streamlit layout and navigation."""

--- a/app/core/navigation.py
+++ b/app/core/navigation.py
@@ -1,0 +1,38 @@
+"""Simple page registry to keep navigation extensible."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+import pandas as pd
+
+from app.views.home import render_home
+from app.views.state import FilterState
+from app.views.visualization import render_visualization
+
+
+RenderFn = Callable[[FilterState, pd.DataFrame], FilterState]
+
+
+@dataclass(frozen=True)
+class Page:
+    """Describes a single Streamlit page."""
+
+    label: str
+    renderer: RenderFn
+    description: str | None = None
+
+
+_DEFAULT_PAGES: tuple[Page, ...] = (
+    Page("🏠 홈", render_home, "필터 기반 홈 대시보드"),
+    Page("📈 시각화", render_visualization, "선택된 FEATURE GROUP 기준 가이드"),
+)
+
+
+def get_pages(extra_pages: Iterable[Page] | None = None) -> Sequence[Page]:
+    """Return the pages that should appear in the sidebar navigation."""
+
+    if not extra_pages:
+        return _DEFAULT_PAGES
+
+    return _DEFAULT_PAGES + tuple(extra_pages)

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -1,0 +1,19 @@
+"""Data utilities for the Streamlit prototype."""
+
+from .data_manager import DataManager
+from .sample_features import (
+    FeatureRecord,
+    distinct_values,
+    load_feature_dataframe,
+    visualization_capabilities,
+    visualization_group_titles,
+)
+
+__all__ = [
+    "DataManager",
+    "FeatureRecord",
+    "distinct_values",
+    "load_feature_dataframe",
+    "visualization_capabilities",
+    "visualization_group_titles",
+]

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -1,6 +1,7 @@
 """Data utilities for the Streamlit prototype."""
 
 from .data_manager import DataManager
+from .runtime_loader import RuntimeContext, load_runtime_context
 from .sample_features import (
     FeatureRecord,
     distinct_values,
@@ -11,6 +12,8 @@ from .sample_features import (
 
 __all__ = [
     "DataManager",
+    "RuntimeContext",
+    "load_runtime_context",
     "FeatureRecord",
     "distinct_values",
     "load_feature_dataframe",

--- a/app/data/data_manager.py
+++ b/app/data/data_manager.py
@@ -1,0 +1,134 @@
+"""Utilities for synchronising feature datasets with remote APIs.
+
+This module keeps a lightweight abstraction for environments where the
+application runs inside the company network (on-prem) and can reach the
+protected Django REST API.  The implementation stores snapshots on disk in
+Parquet format so repeated reads remain fast for the Streamlit app.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pandas as pd
+import requests
+
+_KST = timezone(timedelta(hours=9))
+
+
+@dataclass(slots=True)
+class DataManager:
+    """Fetches feature datasets and caches them locally in Parquet files."""
+
+    api_base: str
+    data_dir: str
+    verify_ssl: bool = True
+    token: str | None = None
+    timeout: int = 20
+
+    def __post_init__(self) -> None:
+        self._base = self.api_base.rstrip("/")
+        self._dir = Path(self.data_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    def refresh_if_stale(self, key: str, *, max_age_hours: int = 24) -> bool:
+        """Synchronise ``key`` if the cached dataset is older than ``max_age_hours``.
+
+        Returns ``True`` when a refresh was attempted successfully.
+        """
+
+        last = self.last_sync_at(key)
+        if last is not None:
+            age = datetime.now(timezone.utc) - last
+            if age < timedelta(hours=max_age_hours):
+                return False
+        try:
+            self._sync(key)
+            return True
+        except requests.RequestException:
+            # Network failures should not crash the Streamlit app; the caller can
+            # fall back to the previously cached dataset or sample data.
+            return False
+
+    def load(self, key: str) -> pd.DataFrame:
+        """Return the cached dataset for ``key`` or an empty frame."""
+
+        path = self._dataset_path(key)
+        if not path.exists():
+            return pd.DataFrame()
+        return pd.read_parquet(path)
+
+    def last_sync_at(self, key: str) -> Optional[datetime]:
+        """Return the last successful sync timestamp in UTC."""
+
+        meta_path = self._meta_path(key)
+        if not meta_path.exists():
+            return None
+        try:
+            payload = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+        raw = payload.get("last_sync")
+        if not raw:
+            return None
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def format_last_sync(value: Optional[datetime]) -> str:
+        """Return a human friendly last-sync message in KST."""
+
+        if value is None:
+            return "미싱크"
+        return value.astimezone(_KST).strftime("%Y-%m-%d %H:%M:%S KST")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _sync(self, key: str) -> None:
+        response = self._fetch_remote(key)
+        dataframe = self._normalise_payload(response)
+        if dataframe.empty:
+            # Persist an empty frame to avoid repeatedly hitting the API when
+            # there is no data yet.
+            dataframe = pd.DataFrame()
+        dataframe.to_parquet(self._dataset_path(key), index=False)
+
+        meta = {"last_sync": datetime.now(timezone.utc).isoformat()}
+        self._meta_path(key).write_text(json.dumps(meta), encoding="utf-8")
+
+    def _fetch_remote(self, key: str) -> Any:
+        url = f"{self._base}/api/{key.strip('/')}/"
+        headers: Dict[str, str] = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        response = requests.get(
+            url,
+            timeout=self.timeout,
+            verify=self.verify_ssl,
+            headers=headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _normalise_payload(payload: Any) -> pd.DataFrame:
+        if isinstance(payload, dict) and "results" in payload:
+            payload = payload["results"]
+        if isinstance(payload, list):
+            return pd.DataFrame.from_records(payload)
+        if isinstance(payload, dict):
+            return pd.DataFrame([payload])
+        return pd.DataFrame()
+
+    def _dataset_path(self, key: str) -> Path:
+        return self._dir / f"{key}.parquet"
+
+    def _meta_path(self, key: str) -> Path:
+        return self._dir / f"{key}.meta.json"

--- a/app/data/runtime_loader.py
+++ b/app/data/runtime_loader.py
@@ -1,0 +1,89 @@
+"""Runtime-aware data loading helpers for the Streamlit app."""
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import pandas as pd
+import requests
+import streamlit as st
+
+from .data_manager import DataManager
+from .sample_features import load_feature_dataframe
+
+
+@dataclass(frozen=True)
+class RuntimeContext:
+    """Encapsulates the dataset and metadata required by the UI."""
+
+    dataframe: pd.DataFrame
+    last_sync_text: str
+    data_manager: Optional[DataManager]
+
+
+@st.cache_data(ttl=86400)
+def _cloud_fetch_feature1(
+    api_base: str, verify_ssl: bool, token: str | None
+) -> tuple[pd.DataFrame, int]:
+    """Fetch feature data from the staging API when running on Streamlit Cloud."""
+
+    url = f"{api_base.rstrip('/')}/api/feature1/"
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(url, timeout=20, verify=verify_ssl, headers=headers)
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict) and "results" in payload:
+        payload = payload["results"]
+    dataframe = pd.DataFrame(payload)
+    return dataframe, int(time.time())
+
+
+def _bool(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def load_runtime_context() -> RuntimeContext:
+    """Return the dataset and metadata for the current runtime environment."""
+
+    runtime_mode = st.secrets.get("RUNTIME_MODE", os.getenv("RUNTIME_MODE", "cloud")).lower()
+    api_base = st.secrets.get("API_BASE", os.getenv("API_BASE", "https://10.x.x.x"))
+    verify_ssl = _bool(str(st.secrets.get("VERIFY_SSL", os.getenv("VERIFY_SSL", "false"))))
+    token = st.secrets.get("API_ACCESS_TOKEN", os.getenv("API_ACCESS_TOKEN"))
+    data_dir = os.getenv("DATA_DIR", "./_cache")
+
+    if runtime_mode == "cloud":
+        try:
+            dataframe, last_epoch = _cloud_fetch_feature1(api_base, verify_ssl, token)
+            if dataframe.empty:
+                last_sync_text = "샘플 데이터(Cloud API 미접속)"
+                dataframe = load_feature_dataframe()
+            else:
+                last_sync = datetime.fromtimestamp(last_epoch, tz=timezone.utc)
+                last_sync_text = DataManager.format_last_sync(last_sync)
+            return RuntimeContext(dataframe=dataframe, last_sync_text=last_sync_text, data_manager=None)
+        except Exception:
+            return RuntimeContext(
+                dataframe=load_feature_dataframe(),
+                last_sync_text="샘플 데이터(Cloud API 미접속)",
+                data_manager=None,
+            )
+
+    data_manager = DataManager(
+        api_base=api_base,
+        data_dir=data_dir,
+        verify_ssl=verify_ssl,
+        token=token,
+    )
+    data_manager.refresh_if_stale("feature1", max_age_hours=24)
+    dataframe = data_manager.load("feature1")
+    if dataframe.empty:
+        dataframe = load_feature_dataframe()
+    last_sync_text = DataManager.format_last_sync(data_manager.last_sync_at("feature1"))
+    return RuntimeContext(dataframe=dataframe, last_sync_text=last_sync_text, data_manager=data_manager)

--- a/app/data/sample_features.py
+++ b/app/data/sample_features.py
@@ -1,0 +1,216 @@
+"""Sample dataset used by the Streamlit prototype.
+
+The dataset now expands to 500 records so the filtering widgets and
+visualisation toggles receive enough diversity when deployed to
+Streamlit Cloud.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from functools import lru_cache
+from itertools import cycle
+from typing import Dict, List
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class FeatureRecord:
+    """Represents a single feature record for the demo application."""
+
+    feature_group: str
+    feature_name: str
+    model: str
+    mcc: str
+    mnc: str
+    region: str
+    country: str
+    operator: str
+    status: str
+    last_updated: str
+    visualization_group: str
+
+
+_BASE_RECORDS: List[FeatureRecord] = [
+    FeatureRecord(
+        feature_group="Roaming Essentials",
+        feature_name="Automatic APN Switch",
+        model="XR-550",
+        mcc="450",
+        mnc="05",
+        region="APAC",
+        country="Korea",
+        operator="SKT",
+        status="Available",
+        last_updated="2025-05-12",
+        visualization_group="Full Suite",
+    ),
+    FeatureRecord(
+        feature_group="Roaming Essentials",
+        feature_name="Dual SIM Failover",
+        model="XR-520",
+        mcc="440",
+        mnc="10",
+        region="APAC",
+        country="Japan",
+        operator="DoCoMo",
+        status="Pilot",
+        last_updated="2025-04-29",
+        visualization_group="Full Suite",
+    ),
+    FeatureRecord(
+        feature_group="Security Core",
+        feature_name="IMS Firewall",
+        model="XR-550",
+        mcc="208",
+        mnc="01",
+        region="EMEA",
+        country="France",
+        operator="Orange",
+        status="Available",
+        last_updated="2025-02-14",
+        visualization_group="Tabular Only",
+    ),
+    FeatureRecord(
+        feature_group="Security Core",
+        feature_name="Signalling Anomaly Detection",
+        model="XR-540",
+        mcc="724",
+        mnc="06",
+        region="LATAM",
+        country="Brazil",
+        operator="Vivo",
+        status="In Progress",
+        last_updated="2025-03-03",
+        visualization_group="Tabular Only",
+    ),
+    FeatureRecord(
+        feature_group="Premium Insights",
+        feature_name="Traffic Heatmap",
+        model="XR-600",
+        mcc="310",
+        mnc="260",
+        region="NA",
+        country="United States",
+        operator="T-Mobile",
+        status="Available",
+        last_updated="2025-06-01",
+        visualization_group="Full Suite",
+    ),
+    FeatureRecord(
+        feature_group="Premium Insights",
+        feature_name="KPI Correlation",
+        model="XR-600",
+        mcc="234",
+        mnc="15",
+        region="EMEA",
+        country="United Kingdom",
+        operator="Vodafone",
+        status="Planned",
+        last_updated="2025-05-05",
+        visualization_group="Full Suite",
+    ),
+    FeatureRecord(
+        feature_group="Connectivity Essentials",
+        feature_name="VoLTE Optimiser",
+        model="XR-520",
+        mcc="404",
+        mnc="45",
+        region="APAC",
+        country="India",
+        operator="Jio",
+        status="Pilot",
+        last_updated="2025-01-25",
+        visualization_group="Tabular Only",
+    ),
+    FeatureRecord(
+        feature_group="Connectivity Essentials",
+        feature_name="NR Fallback Enhancer",
+        model="XR-530",
+        mcc="262",
+        mnc="02",
+        region="EMEA",
+        country="Germany",
+        operator="Telekom",
+        status="Available",
+        last_updated="2025-04-17",
+        visualization_group="Full Suite",
+    ),
+]
+
+
+def _build_dataset(total: int = 500) -> List[FeatureRecord]:
+    statuses = ["Available", "Pilot", "In Progress", "Planned"]
+    records: List[FeatureRecord] = []
+    for index, template in enumerate(cycle(_BASE_RECORDS), start=1):
+        if len(records) >= total:
+            break
+
+        batch = (index - 1) // len(_BASE_RECORDS) + 1
+        suffix = f"{batch:02d}"
+        last_updated = (
+            datetime.strptime(template.last_updated, "%Y-%m-%d")
+            + timedelta(days=(index - 1) % 45)
+        ).strftime("%Y-%m-%d")
+
+        record = FeatureRecord(
+            feature_group=template.feature_group,
+            feature_name=f"{template.feature_name} #{suffix}",
+            model=f"{template.model}-{(batch % 5) + 1}",
+            mcc=f"{(int(template.mcc) + index) % 1000:03d}",
+            mnc=f"{(int(template.mnc) + batch) % 1000:03d}",
+            region=template.region,
+            country=template.country,
+            operator=f"{template.operator} {batch}",
+            status=statuses[(batch - 1) % len(statuses)],
+            last_updated=last_updated,
+            visualization_group=template.visualization_group,
+        )
+        records.append(record)
+    return records
+
+
+_DATA: List[FeatureRecord] = _build_dataset(500)
+
+
+@lru_cache(maxsize=1)
+def load_feature_dataframe() -> pd.DataFrame:
+    """Return the feature dataset as a pandas DataFrame."""
+
+    frame = pd.DataFrame([record.__dict__ for record in _DATA])
+    frame.sort_values(["feature_group", "feature_name"], inplace=True)
+    frame.reset_index(drop=True, inplace=True)
+    return frame
+
+
+def distinct_values(column: str) -> List[str]:
+    """Return sorted distinct values for the requested column."""
+
+    df = load_feature_dataframe()
+    return sorted(df[column].dropna().unique().tolist())
+
+
+@lru_cache(maxsize=None)
+def visualization_capabilities() -> Dict[str, List[str]]:
+    """Map each visualization group to the UI elements it supports."""
+
+    return {
+        "Full Suite": [
+            "Feature summary table",
+            "Time series / KPI charts",
+            "Traffic density heatmap",
+            "Geo heatmap (Leaflet)",
+        ],
+        "Tabular Only": [
+            "Feature summary table",
+        ],
+    }
+
+
+@lru_cache(maxsize=None)
+def visualization_group_titles() -> Dict[str, str]:
+    return {
+        "Full Suite": "그룹 1 – 전체 시각화 지원",
+        "Tabular Only": "그룹 2 – 표 기반 시각화",
+    }

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -1,0 +1,3 @@
+"""Streamlit view implementations for the prototype."""
+
+__all__ = ["home", "visualization", "state"]

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -1,0 +1,119 @@
+"""Home view that focuses on feature discovery and filtering."""
+from __future__ import annotations
+
+from typing import Optional
+
+import streamlit as st
+
+from app.data.data_manager import DataManager
+from app.data.sample_features import distinct_values
+from app.views.state import FilterState
+
+
+def _multiselect(label: str, options, default, key: str):
+    return st.multiselect(
+        label,
+        options,
+        default=default,
+        key=key,
+        placeholder="검색하거나 값을 입력하세요",
+    )
+
+
+def _column_options(dataframe, column: str):
+    if column in dataframe.columns:
+        values = dataframe[column].dropna().astype(str).unique().tolist()
+        values.sort()
+        return values
+    return distinct_values(column)
+
+
+def render_home(filter_state: FilterState, dataframe):
+    """Render the main landing page with detailed filters."""
+
+    st.title("📊 Feature Monitoring Home")
+
+    data_manager: Optional[DataManager] = st.session_state.get("data_manager")
+    if data_manager:
+        last_sync = data_manager.last_sync_at("feature1")
+        last_sync_text = data_manager.format_last_sync(last_sync)
+    else:
+        last_sync_text = st.session_state.get("last_sync_txt", "샘플 데이터")
+
+    st.caption(
+        f"마지막 DB 싱크: **{last_sync_text}** · 싱크 주기: **매일 1회** · 이 화면은 **조회 전용**입니다."
+    )
+
+    st.markdown(
+        """
+        - 좌측 사이드바에서 **모델**과 **FEATURE GROUP**을 선택하면 전체 필터가 좁혀집니다.
+        - 아래 상세 필터에서 MCC, MNC, 국가/사업자 등을 추가로 지정해 원하는 레코드를 찾을 수 있습니다.
+        - 선택한 레코드는 테이블 형태로 표시되어 바로 운영자가 검토할 수 있습니다.
+        """
+    )
+
+    st.subheader("상세 필터")
+    col1, col2, col3 = st.columns(3)
+
+    with col1:
+        filter_state.mcc = _multiselect(
+            "MCC",
+            _column_options(dataframe, "mcc"),
+            filter_state.mcc,
+            "home_mcc",
+        )
+        filter_state.mnc = _multiselect(
+            "MNC",
+            _column_options(dataframe, "mnc"),
+            filter_state.mnc,
+            "home_mnc",
+        )
+
+    with col2:
+        filter_state.regions = _multiselect(
+            "지역",
+            _column_options(dataframe, "region"),
+            filter_state.regions,
+            "home_region",
+        )
+        filter_state.countries = _multiselect(
+            "국가",
+            _column_options(dataframe, "country"),
+            filter_state.countries,
+            "home_country",
+        )
+
+    with col3:
+        filter_state.operators = _multiselect(
+            "사업자",
+            _column_options(dataframe, "operator"),
+            filter_state.operators,
+            "home_operator",
+        )
+        filter_state.features = _multiselect(
+            "FEATURE",
+            _column_options(dataframe, "feature_name"),
+            filter_state.features,
+            "home_feature",
+        )
+
+    filtered_df = filter_state.apply(dataframe)
+
+    st.divider()
+    st.subheader("선택한 FEATURE GROUP 레코드")
+
+    st.write(
+        f"총 **{len(filtered_df)}**건이 선택되었습니다. 필요한 데이터를 바로 다운로드할 수 있도록 준비 중입니다."
+    )
+
+    st.dataframe(
+        filtered_df,
+        hide_index=True,
+        use_container_width=True,
+    )
+
+    st.info(
+        "해당 화면은 한 명의 담당자가 운영하도록 설계되었습니다. 홈 화면에서 바로 필터를 적용한 후 데이터를 검토하고 관리할 수 있습니다."
+    )
+
+    return filter_state

--- a/app/views/state.py
+++ b/app/views/state.py
@@ -1,0 +1,49 @@
+"""Shared data structures that describe the UI state across views."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class FilterState:
+    """Represents the currently selected filters."""
+
+    models: List[str] = field(default_factory=list)
+    feature_groups: List[str] = field(default_factory=list)
+    mcc: List[str] = field(default_factory=list)
+    mnc: List[str] = field(default_factory=list)
+    regions: List[str] = field(default_factory=list)
+    countries: List[str] = field(default_factory=list)
+    operators: List[str] = field(default_factory=list)
+    features: List[str] = field(default_factory=list)
+
+    def apply(self, dataframe):
+        """Return a filtered dataframe based on the state selections."""
+
+        df = dataframe
+        selectors = {
+            "model": self.models,
+            "feature_group": self.feature_groups,
+            "mcc": self.mcc,
+            "mnc": self.mnc,
+            "region": self.regions,
+            "country": self.countries,
+            "operator": self.operators,
+            "feature_name": self.features,
+        }
+
+        for column, selected in selectors.items():
+            if selected:
+                df = df[df[column].isin(selected)]
+        return df
+
+    def active_visualization_groups(self, dataframe) -> List[str]:
+        """Return distinct visualization groups for the filtered dataframe."""
+
+        filtered = self.apply(dataframe)
+        if "visualization_group" not in filtered.columns:
+            return []
+        groups = filtered["visualization_group"].dropna().unique().tolist()
+        groups.sort()
+        return groups

--- a/app/views/visualization.py
+++ b/app/views/visualization.py
@@ -1,0 +1,74 @@
+"""Visualization view that adapts to the selected feature groups."""
+from __future__ import annotations
+
+import streamlit as st
+
+from app.data.sample_features import (
+    visualization_capabilities,
+    visualization_group_titles,
+)
+from app.views.state import FilterState
+
+
+def render_visualization(filter_state: FilterState, dataframe):
+    st.title("📈 Visualization Workspace")
+    st.caption("선택된 FEATURE GROUP에 따라 사용 가능한 시각화 유형이 달라집니다.")
+    st.info("이 영역은 **작업 중(WIP)** 입니다. 차트와 지도 템플릿은 순차적으로 연결됩니다.")
+
+    groups = filter_state.active_visualization_groups(dataframe)
+    titles = visualization_group_titles()
+    capabilities = visualization_capabilities()
+
+    if not groups:
+        st.info(
+            "사이드바와 홈 화면에서 FEATURE GROUP을 선택하면 여기에서 사용할 수 있는 시각화 유형이 노출됩니다."
+        )
+        st.stop()
+
+    readable = [titles.get(group, group) for group in groups]
+    default_label = readable[0]
+
+    selected_label = st.selectbox(
+        "시각화 그룹",
+        readable,
+        key="viz_group_selector",
+    )
+
+    # Map back to canonical key
+    inverse_titles = {v: k for k, v in titles.items()}
+    selected_group = inverse_titles.get(selected_label, selected_label)
+
+    st.markdown("### 지원되는 시각화")
+    for item in capabilities.get(selected_group, []):
+        st.markdown(f"- {item}")
+
+    st.divider()
+    st.markdown("### 시각화 출력")
+
+    if selected_group == "Tabular Only":
+        st.success("현재 그룹은 표 기반 시각화만 지원합니다. 아래 표로 데이터를 확인하세요.")
+        st.dataframe(
+            filter_state.apply(dataframe),
+            hide_index=True,
+            use_container_width=True,
+        )
+    else:
+        st.success(
+            "차트, 히트맵 지도, KPI 비교 등 다양한 시각화 템플릿을 순차적으로 배치할 예정입니다."
+        )
+        col1, col2 = st.columns(2)
+        with col1:
+            st.empty()
+            st.warning("📊 라인 차트 영역 – 데이터 연동 대기 중")
+        with col2:
+            st.empty()
+            st.warning("🗺️ 히트맵 지도 영역 – GIS 데이터 연동 대기 중")
+
+        st.info("필요한 경우 아래 표로 세부 데이터를 동시에 확인할 수 있습니다.")
+        st.dataframe(
+            filter_state.apply(dataframe),
+            hide_index=True,
+            use_container_width=True,
+        )
+
+    st.caption("해당 공간은 시각화 담당자가 독립적으로 관리합니다.")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,157 @@
+"""Streamlit entry point implementing the dual cloud/on-prem workflow."""
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from typing import List
+
+import pandas as pd
+import requests
+import streamlit as st
+
+from app.core.navigation import get_pages
+from app.data.data_manager import DataManager
+from app.data.sample_features import load_feature_dataframe
+from app.views.state import FilterState
+
+
+def _init_session_state() -> FilterState:
+    if "filter_state" not in st.session_state:
+        st.session_state.filter_state = FilterState()
+    return st.session_state.filter_state
+
+
+def _sorted_unique(dataframe: pd.DataFrame, column: str) -> List[str]:
+    if column in dataframe.columns:
+        values = dataframe[column].dropna().astype(str).unique().tolist()
+        values.sort()
+        return values
+    return []
+
+
+def _render_sidebar(filter_state: FilterState, dataframe: pd.DataFrame) -> str:
+    pages = get_pages()
+    labels = [page.label for page in pages]
+
+    st.sidebar.title("🧭 내비게이션")
+    selected_label = st.sidebar.radio(
+        "메인 기능",
+        labels,
+        key="main_navigation",
+    )
+
+    selected_page = next(page for page in pages if page.label == selected_label)
+    if selected_page.description:
+        st.sidebar.caption(selected_page.description)
+
+    st.sidebar.divider()
+    st.sidebar.subheader("공통 필터")
+
+    model_options = _sorted_unique(dataframe, "model")
+    feature_group_options = _sorted_unique(dataframe, "feature_group")
+
+    if not model_options:
+        model_options = _sorted_unique(load_feature_dataframe(), "model")
+    if not feature_group_options:
+        feature_group_options = _sorted_unique(load_feature_dataframe(), "feature_group")
+
+    filter_state.models = st.sidebar.multiselect(
+        "모델",
+        model_options,
+        default=filter_state.models,
+        key="sidebar_models",
+        placeholder="모델을 선택하세요",
+    )
+    filter_state.feature_groups = st.sidebar.multiselect(
+        "FEATURE GROUP",
+        feature_group_options,
+        default=filter_state.feature_groups,
+        key="sidebar_feature_groups",
+        placeholder="FEATURE GROUP을 선택하세요",
+    )
+
+    st.sidebar.caption("선택한 항목은 모든 화면의 데이터 필터에 바로 반영됩니다.")
+
+    st.sidebar.divider()
+    st.sidebar.subheader("확장 앱")
+    st.sidebar.caption("추가 기능(챗봇, 자동화 등)을 연결할 영역입니다.")
+
+    return selected_label
+
+
+@st.cache_data(ttl=86400)
+def _cloud_fetch_feature1(api_base: str, verify_ssl: bool, token: str | None) -> tuple[pd.DataFrame, int]:
+    """Fetch feature data from the public staging API (cloud mode)."""
+
+    url = f"{api_base.rstrip('/')}/api/feature1/"
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(url, timeout=20, verify=verify_ssl, headers=headers)
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict) and "results" in payload:
+        payload = payload["results"]
+    dataframe = pd.DataFrame(payload)
+    return dataframe, int(time.time())
+
+
+def _bool(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def main():
+    st.set_page_config(page_title="Feature Monitoring Portal", layout="wide")
+
+    filter_state = _init_session_state()
+
+    runtime_mode = st.secrets.get("RUNTIME_MODE", os.getenv("RUNTIME_MODE", "cloud")).lower()
+    api_base = st.secrets.get("API_BASE", os.getenv("API_BASE", "https://10.x.x.x"))
+    verify_ssl = _bool(str(st.secrets.get("VERIFY_SSL", os.getenv("VERIFY_SSL", "false"))))
+    token = st.secrets.get("API_ACCESS_TOKEN", os.getenv("API_ACCESS_TOKEN"))
+    data_dir = os.getenv("DATA_DIR", "./_cache")
+
+    if runtime_mode == "cloud":
+        try:
+            dataframe, last_epoch = _cloud_fetch_feature1(api_base, verify_ssl, token)
+            st.session_state["data_manager"] = None
+            if dataframe.empty:
+                dataframe = load_feature_dataframe()
+                st.session_state["last_sync_txt"] = "샘플 데이터(Cloud API 미접속)"
+            else:
+                last_sync = datetime.fromtimestamp(last_epoch, tz=timezone.utc)
+                st.session_state["last_sync_txt"] = DataManager.format_last_sync(last_sync)
+        except Exception:
+            dataframe = load_feature_dataframe()
+            st.session_state["data_manager"] = None
+            st.session_state["last_sync_txt"] = "샘플 데이터(Cloud API 미접속)"
+    else:
+        data_manager = DataManager(
+            api_base=api_base,
+            data_dir=data_dir,
+            verify_ssl=verify_ssl,
+            token=token,
+        )
+        st.session_state["data_manager"] = data_manager
+        data_manager.refresh_if_stale("feature1", max_age_hours=24)
+        dataframe = data_manager.load("feature1")
+        if dataframe.empty:
+            dataframe = load_feature_dataframe()
+        st.session_state["last_sync_txt"] = DataManager.format_last_sync(
+            data_manager.last_sync_at("feature1")
+        )
+
+    st.session_state["active_dataframe"] = dataframe
+
+    selected_label = _render_sidebar(filter_state, dataframe)
+    pages = {page.label: page.renderer for page in get_pages()}
+
+    updated_state = pages[selected_label](filter_state, dataframe)
+    st.session_state.filter_state = updated_state
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.33,<2.0
+pandas>=2.0,<3.0
+requests>=2.31
+pyarrow>=14.0


### PR DESCRIPTION
## Summary
- add a DataManager with Parquet caching and update the Streamlit entry point to switch between cloud and on-prem modes with cached API fetches
- expand the sample feature dataset to 500 generated records and re-export data utilities for wider reuse
- show the last sync timestamp on the home view, add a visualization WIP banner, and refresh the README and requirements for cloud deployment

## Testing
- not run (pandas dependency unavailable in sandbox)


------
https://chatgpt.com/codex/tasks/task_b_68df87312d4c832f831c74423a76c57a